### PR TITLE
Fix URL for rezound

### DIFF
--- a/trunk/Rezound/0.10.0beta/Recipe
+++ b/trunk/Rezound/0.10.0beta/Recipe
@@ -1,7 +1,7 @@
 # Recipe (MakeRecipe) for Rezound by ro.ko@mcnon.com, on Fri Oct 15 21:51:34 BRST 2004
 # Recipe for version 0.10.0beta by ro.ko@mcnon.com, on Fri Oct 15 21:51:34 BRST 2004
 compile_version=1.8.0
-url="httpSourceforge/rezound/rezound-0.10.0beta.tar.gz"
+url="$httpSourceforge/rezound/rezound-0.10.0beta.tar.gz"
 file_size=1483212
 file_md5=607740eca99e36c1f1ca1d01b91cb5bf
 recipe_type=configure


### PR DESCRIPTION
Just an error found by repology.org. I'm not sure what's the policy of submitting to trunk/ vs. revisions/. Should I change it in revisions/ as well?