### PR TITLE
Git 2.29.2

### DIFF
--- a/Git/2.29.2/Resources/BuildDependencies
+++ b/Git/2.29.2/Resources/BuildDependencies
@@ -1,5 +1,5 @@
 DocBook-XSL-Stylesheets
 XMLTO >= 0.0.20
-AsciiDoc >= 8.2.5
+AsciiDoc >= 9.0.4
 DocBook-XML-DTD >= 4.5
 LibXSLT >= 1.1.22


### PR DESCRIPTION
`Git 2.29.2` needed `AsciiDoc >= 9.0.4` to compile correctly for me :)