### PR TITLE
Update GTK 2.3.0 Recipe

### DIFF
--- a/GTK+/2.3.0/Recipe
+++ b/GTK+/2.3.0/Recipe
@@ -1,6 +1,7 @@
 # by Giusepe Casagrande
 
 url="http://ftp.gnome.org/pub/GNOME/sources/gtk+/2.3/gtk+-2.3.0.tar.bz2"
+file_size=7691811
 configure_options=(
 	"--with-x"
 	"--with-libpng"


### PR DESCRIPTION
Add file_size

Resolves
```
HTTP request sent, awaiting response... 200 OK
Length: 7691811 (7.3M) [application/x-bzip2]
Saving to: 'gtk+-2.3.0.tar.bz2'

gtk+-2.3.0.tar.bz2  100%[=================>]   7.33M  9.44MB/s    in 0.8s    

2021-08-18 20:15:46 (9.44 MB/s) - 'gtk+-2.3.0.tar.bz2' saved [7691811/7691811]

FetchArchive: Warning: no file size or MD5/SHA checksum. /Data/Compile/Archives/gtk+-2.3.0.tar.bz2 cannot be verified
FetchArchive: File /Data/Compile/Archives/gtk+-2.3.0.tar.bz2 is incomplete or can not be verified
Compile: Error fetching archive(s).
Compile: GTK+ 2.3.0 - Fetching sources failed

```