### PR TITLE
Tmux 3.4

### DIFF
--- a/Tmux/3.4/Recipe
+++ b/Tmux/3.4/Recipe
@@ -1,0 +1,7 @@
+# Recipe for version 3.4 by Sage I. Hendricks <sage.message@email.com>, on Wed 10 Apr 2024 09:32:49 AM EDT
+# Recipe (MakeRecipe) for Tmux by Jonas Karlsson <jonas@gobolinux.org>, on Sun May 10 22:15:01 CEST 2009
+compile_version=017GIT
+url="https://github.com/tmux/tmux/releases/download/3.4/tmux-3.4.tar.gz"
+file_size=707213
+file_md5=f6e35f957f91af5bb07cb8449228f5cd
+recipe_type=configure

--- a/Tmux/3.4/Resources/BuildDependencies
+++ b/Tmux/3.4/Resources/BuildDependencies
@@ -1,0 +1,2 @@
+Pkgconfig
+Bison

--- a/Tmux/3.4/Resources/Dependencies
+++ b/Tmux/3.4/Resources/Dependencies
@@ -1,0 +1,3 @@
+Glibc >= 2.30
+LibEvent >= 2.0.0, < 3.0.0
+NcursesW

--- a/Tmux/3.4/Resources/Description
+++ b/Tmux/3.4/Resources/Description
@@ -1,0 +1,8 @@
+[Name] Tmux
+[Summary] A terminal multiplexer
+[Description] tmux is a "terminal multiplexer", it enables a number of
+terminals (or windows) to be accessed and controlled from a single
+terminal. tmux is intended to be a simple, modern, BSD-licensed
+alternative to programs such as GNU screen.
+[License] BSD
+[Homepage] https://github.com/tmux/tmux/wiki


### PR DESCRIPTION
- removed the `BuildInformation` file
- added a `BuildDependencies` file
- updated the homepage to their git repo <https://github.com/tmux/tmux/wiki>.