### PR TITLE
Awesome 4.3 patch (lua54 compatibility)

### DIFF
--- a/Awesome/4.3/01-fix-lua54-version.patch
+++ b/Awesome/4.3/01-fix-lua54-version.patch
@@ -1,0 +1,19 @@
+As of Lua54, 'require' now pushes 2 values onto the stack. While all prior 
+versions only pushed 1 value. 
+
+Due to this, when using Lua 5.4 the `--version` flag would return bad version
+information. This patch fixes that.
+
+
+--- ../common/version.c.orig	2024-05-02 18:29:54.116685697 -0400
++++ ../common/version.c	2024-05-02 18:59:59.483356091 -0400
+@@ -48,7 +48,9 @@
+         lua_pop(L, 1);
+ 
+     /* Either push version number or error message onto stack */
++    int top = lua_gettop(L);
+     (void) luaL_dostring(L, "return require('lgi.version')");
++    lua_pop(L, lua_gettop(L) - top - 1);
+ 
+ #ifdef WITH_DBUS
+     const char *has_dbus = "yes";

--- a/Awesome/4.3/01-fix-lua54-version.patch
+++ b/Awesome/4.3/01-fix-lua54-version.patch
@@ -1,9 +1,7 @@
-As of Lua54, 'require' now pushes 2 values onto the stack. While all prior 
-versions only pushed 1 value. 
-
-Due to this, when using Lua 5.4 the `--version` flag would return bad version
-information. This patch fixes that.
-
+As of Lua5.4 'require' returns both the version number and a path to the 
+version file. Awesome's version function expects the builtin to only return 
+the version number. This patch chops off all extra returns and presents it
+as though it only returned 1 value. 
 
 --- ../common/version.c.orig	2024-05-02 18:29:54.116685697 -0400
 +++ ../common/version.c	2024-05-02 18:59:59.483356091 -0400


### PR DESCRIPTION
Awesome's `-v` version flag, was written with Lua53's `require` in mind, which only returns 1 value. However, in Lua54, the `require` built-in now returns 2 values. Awesome doesn't handle this causing the version information to display incorrectly.

Rather than checking `LUA_VERSION_NUM`, the patch handles this at runtime, so no matter the version of Lua used at build time, the runtime information should be correct for the given Lua + LGI softwares.

I tested the patch with Lua versions: `5.4.3`, `5.3.5`, and `5.3.6`, and it works in each.

Example (w/o the patch) running Lua 5.4.3 and LGI-GIT:
```
$ awesome -v
awesome v4.3 (Too long)
 ? Compiled against Lua 5.4.3 (running with 0.9.2)
 ? D-Bus support: ?
 ? execinfo support: ?
 ? xcb-randr version: 1.6
 ? LGI version: /System/Aliens/LuaRocks/share/lua/5.4/lgi/version.lua
```

Example (w/ the patch)
```
$ awesome -v
awesome v4.3 (Too long)
 ? Compiled against Lua 5.4.3 (running with Lua 5.4)
 ? D-Bus support: ?
 ? execinfo support: ?
 ? xcb-randr version: 1.6
 ? LGI version: 0.9.2
```

The patch isn't essential, Awesome will run fine without it, but it's nice having the version information not be wrong ://

for Issue #128