### PR TITLE
Fix a race condition between Lua and LuaRocks

### DIFF
--- a/Lua/5.3.0/Resources/Environment
+++ b/Lua/5.3.0/Resources/Environment
@@ -7,10 +7,12 @@ $goboShared/lua/5.1/?.lua;\
 $goboShared/lua/5.1/?/init.lua;\
 $goboLibraries/lua/5.1/?.lua;\
 $goboLibraries/lua/5.1/?/init.lua;\
+$LUA_PATH\
 "
 
 export LUA_CPATH="\
 ./?.so;\
 $goboLibraries/lua/5.1/?.so;\
-$goboLibraries/lua/5.1/loadall.so\
+$goboLibraries/lua/5.1/loadall.so;\
+$LUA_CPATH\
 "

--- a/Lua/5.3.2/Resources/Environment
+++ b/Lua/5.3.2/Resources/Environment
@@ -7,10 +7,12 @@ $goboShared/lua/5.1/?.lua;\
 $goboShared/lua/5.1/?/init.lua;\
 $goboLibraries/lua/5.1/?.lua;\
 $goboLibraries/lua/5.1/?/init.lua;\
+$LUA_PATH\
 "
 
 export LUA_CPATH="\
 ./?.so;\
 $goboLibraries/lua/5.1/?.so;\
-$goboLibraries/lua/5.1/loadall.so\
+$goboLibraries/lua/5.1/loadall.so;\
+$LUA_CPATH\
 "

--- a/Lua/5.3.3/Resources/Environment
+++ b/Lua/5.3.3/Resources/Environment
@@ -7,10 +7,12 @@ $goboShared/lua/5.3/?.lua;\
 $goboShared/lua/5.3/?/init.lua;\
 $goboLibraries/lua/5.3/?.lua;\
 $goboLibraries/lua/5.3/?/init.lua;\
+$LUA_PATH_5_3\
 "
 
 export LUA_CPATH_5_3="\
 ./?.so;\
 $goboLibraries/lua/5.3/?.so;\
-$goboLibraries/lua/5.3/loadall.so\
+$goboLibraries/lua/5.3/loadall.so;\
+$LUA_CPATH_5_3\
 "

--- a/Lua/5.3.4/Resources/Environment
+++ b/Lua/5.3.4/Resources/Environment
@@ -7,10 +7,12 @@ $goboShared/lua/5.3/?.lua;\
 $goboShared/lua/5.3/?/init.lua;\
 $goboLibraries/lua/5.3/?.lua;\
 $goboLibraries/lua/5.3/?/init.lua;\
+$LUA_PATH_5_3\
 "
 
 export LUA_CPATH_5_3="\
 ./?.so;\
 $goboLibraries/lua/5.3/?.so;\
-$goboLibraries/lua/5.3/loadall.so\
+$goboLibraries/lua/5.3/loadall.so;\
+$LUA_CPATH_5_3\
 "

--- a/Lua/5.3.5/Resources/Environment
+++ b/Lua/5.3.5/Resources/Environment
@@ -7,10 +7,12 @@ $goboShared/lua/5.3/?.lua;\
 $goboShared/lua/5.3/?/init.lua;\
 $goboLibraries/lua/5.3/?.lua;\
 $goboLibraries/lua/5.3/?/init.lua;\
+$LUA_PATH_5_3\
 "
 
 export LUA_CPATH_5_3="\
 ./?.so;\
 $goboLibraries/lua/5.3/?.so;\
-$goboLibraries/lua/5.3/loadall.so\
+$goboLibraries/lua/5.3/loadall.so;\
+$LUA_CPATH_5_3\
 "

--- a/Lua/5.3.6/Resources/Environment
+++ b/Lua/5.3.6/Resources/Environment
@@ -7,10 +7,12 @@ $goboShared/lua/5.3/?.lua;\
 $goboShared/lua/5.3/?/init.lua;\
 $goboLibraries/lua/5.3/?.lua;\
 $goboLibraries/lua/5.3/?/init.lua;\
+$LUA_PATH_5_3\
 "
 
 export LUA_CPATH_5_3="\
 ./?.so;\
 $goboLibraries/lua/5.3/?.so;\
-$goboLibraries/lua/5.3/loadall.so\
+$goboLibraries/lua/5.3/loadall.so;\
+$LUA_CPATH_5_3\
 "

--- a/Lua/5.4.2/Resources/Environment
+++ b/Lua/5.4.2/Resources/Environment
@@ -7,10 +7,12 @@ $goboShared/lua/5.4/?.lua;\
 $goboShared/lua/5.4/?/init.lua;\
 $goboLibraries/lua/5.4/?.lua;\
 $goboLibraries/lua/5.4/?/init.lua;\
+$LUA_PATH_5_4\
 "
 
 export LUA_CPATH_5_4="\
 ./?.so;\
 $goboLibraries/lua/5.4/?.so;\
-$goboLibraries/lua/5.4/loadall.so\
+$goboLibraries/lua/5.4/loadall.so;\
+$LUA_CPATH_5_4\
 "

--- a/Lua/5.4.3/Resources/Environment
+++ b/Lua/5.4.3/Resources/Environment
@@ -7,10 +7,12 @@ $goboShared/lua/5.4/?.lua;\
 $goboShared/lua/5.4/?/init.lua;\
 $goboLibraries/lua/5.4/?.lua;\
 $goboLibraries/lua/5.4/?/init.lua;\
+$LUA_PATH_5_4\
 "
 
 export LUA_CPATH_5_4="\
 ./?.so;\
 $goboLibraries/lua/5.4/?.so;\
-$goboLibraries/lua/5.4/loadall.so\
+$goboLibraries/lua/5.4/loadall.so;\
+$LUA_CPATH_5_4\
 "

--- a/LuaRocks/3.0.1/Resources/Environment
+++ b/LuaRocks/3.0.1/Resources/Environment
@@ -5,15 +5,15 @@ do
   v="${vk%=*}"
   k="${vk#*=}"
 
-export LUA_PATH$k="\
-$goboSystem/Aliens/LuaRocks/share/lua/$v/?.lua;\
+export LUA_PATH$k+="\
+;$goboSystem/Aliens/LuaRocks/share/lua/$v/?.lua;\
 $goboSystem/Aliens/LuaRocks/share/lua/$v/?/init.lua;\
 $goboSystem/Aliens/LuaRocks/lib/lua/$v/?.lua;\
-$goboSystem/Aliens/LuaRocks/lib/lua/$v/?/init.lua;;"
+$goboSystem/Aliens/LuaRocks/lib/lua/$v/?/init.lua"
 
-export LUA_CPATH$k="\
-$goboSystem/Aliens/LuaRocks/lib/lua/$v/?.so;\
-$goboSystem/Aliens/LuaRocks/lib/lua/$v/loadall.so;;"
+export LUA_CPATH$k+="\
+;$goboSystem/Aliens/LuaRocks/lib/lua/$v/?.so;\
+$goboSystem/Aliens/LuaRocks/lib/lua/$v/loadall.so"
 
 done
 unset v k vk

--- a/LuaRocks/3.0.4/Resources/Environment
+++ b/LuaRocks/3.0.4/Resources/Environment
@@ -5,15 +5,15 @@ do
   v="${vk%=*}"
   k="${vk#*=}"
 
-export LUA_PATH$k="\
-$goboSystem/Aliens/LuaRocks/share/lua/$v/?.lua;\
+export LUA_PATH$k+="\
+;$goboSystem/Aliens/LuaRocks/share/lua/$v/?.lua;\
 $goboSystem/Aliens/LuaRocks/share/lua/$v/?/init.lua;\
 $goboSystem/Aliens/LuaRocks/lib/lua/$v/?.lua;\
-$goboSystem/Aliens/LuaRocks/lib/lua/$v/?/init.lua;;"
+$goboSystem/Aliens/LuaRocks/lib/lua/$v/?/init.lua"
 
-export LUA_CPATH$k="\
-$goboSystem/Aliens/LuaRocks/lib/lua/$v/?.so;\
-$goboSystem/Aliens/LuaRocks/lib/lua/$v/loadall.so;;"
+export LUA_CPATH$k+="\
+;$goboSystem/Aliens/LuaRocks/lib/lua/$v/?.so;\
+$goboSystem/Aliens/LuaRocks/lib/lua/$v/loadall.so"
 
 done
 unset v k vk

--- a/LuaRocks/3.1.3/Resources/Environment
+++ b/LuaRocks/3.1.3/Resources/Environment
@@ -5,15 +5,15 @@ do
   v="${vk%=*}"
   k="${vk#*=}"
 
-export LUA_PATH$k="\
-$goboSystem/Aliens/LuaRocks/share/lua/$v/?.lua;\
+export LUA_PATH$k+="\
+;$goboSystem/Aliens/LuaRocks/share/lua/$v/?.lua;\
 $goboSystem/Aliens/LuaRocks/share/lua/$v/?/init.lua;\
 $goboSystem/Aliens/LuaRocks/lib/lua/$v/?.lua;\
-$goboSystem/Aliens/LuaRocks/lib/lua/$v/?/init.lua;;"
+$goboSystem/Aliens/LuaRocks/lib/lua/$v/?/init.lua"
 
-export LUA_CPATH$k="\
-$goboSystem/Aliens/LuaRocks/lib/lua/$v/?.so;\
-$goboSystem/Aliens/LuaRocks/lib/lua/$v/loadall.so;;"
+export LUA_CPATH$k+="\
+;$goboSystem/Aliens/LuaRocks/lib/lua/$v/?.so;\
+$goboSystem/Aliens/LuaRocks/lib/lua/$v/loadall.so"
 
 done
 unset v k vk

--- a/LuaRocks/3.2.1/Resources/Environment
+++ b/LuaRocks/3.2.1/Resources/Environment
@@ -5,15 +5,15 @@ do
   v="${vk%=*}"
   k="${vk#*=}"
 
-export LUA_PATH$k="\
-$goboSystem/Aliens/LuaRocks/share/lua/$v/?.lua;\
+export LUA_PATH$k+="\
+;$goboSystem/Aliens/LuaRocks/share/lua/$v/?.lua;\
 $goboSystem/Aliens/LuaRocks/share/lua/$v/?/init.lua;\
 $goboSystem/Aliens/LuaRocks/lib/lua/$v/?.lua;\
-$goboSystem/Aliens/LuaRocks/lib/lua/$v/?/init.lua;;"
+$goboSystem/Aliens/LuaRocks/lib/lua/$v/?/init.lua"
 
-export LUA_CPATH$k="\
-$goboSystem/Aliens/LuaRocks/lib/lua/$v/?.so;\
-$goboSystem/Aliens/LuaRocks/lib/lua/$v/loadall.so;;"
+export LUA_CPATH$k+="\
+;$goboSystem/Aliens/LuaRocks/lib/lua/$v/?.so;\
+$goboSystem/Aliens/LuaRocks/lib/lua/$v/loadall.so"
 
 done
 unset v k vk

--- a/LuaRocks/3.3.1/Resources/Environment
+++ b/LuaRocks/3.3.1/Resources/Environment
@@ -5,15 +5,15 @@ do
   v="${vk%=*}"
   k="${vk#*=}"
 
-export LUA_PATH$k="\
-$goboSystem/Aliens/LuaRocks/share/lua/$v/?.lua;\
+export LUA_PATH$k+="\
+;$goboSystem/Aliens/LuaRocks/share/lua/$v/?.lua;\
 $goboSystem/Aliens/LuaRocks/share/lua/$v/?/init.lua;\
 $goboSystem/Aliens/LuaRocks/lib/lua/$v/?.lua;\
-$goboSystem/Aliens/LuaRocks/lib/lua/$v/?/init.lua;;"
+$goboSystem/Aliens/LuaRocks/lib/lua/$v/?/init.lua"
 
-export LUA_CPATH$k="\
-$goboSystem/Aliens/LuaRocks/lib/lua/$v/?.so;\
-$goboSystem/Aliens/LuaRocks/lib/lua/$v/loadall.so;;"
+export LUA_CPATH$k+="\
+;$goboSystem/Aliens/LuaRocks/lib/lua/$v/?.so;\
+$goboSystem/Aliens/LuaRocks/lib/lua/$v/loadall.so"
 
 done
 unset v k vk

--- a/LuaRocks/3.5.0/Resources/Environment
+++ b/LuaRocks/3.5.0/Resources/Environment
@@ -5,15 +5,15 @@ do
   v="${vk%=*}"
   k="${vk#*=}"
 
-export LUA_PATH$k="\
-$goboSystem/Aliens/LuaRocks/share/lua/$v/?.lua;\
+export LUA_PATH$k+="\
+;$goboSystem/Aliens/LuaRocks/share/lua/$v/?.lua;\
 $goboSystem/Aliens/LuaRocks/share/lua/$v/?/init.lua;\
 $goboSystem/Aliens/LuaRocks/lib/lua/$v/?.lua;\
-$goboSystem/Aliens/LuaRocks/lib/lua/$v/?/init.lua;;"
+$goboSystem/Aliens/LuaRocks/lib/lua/$v/?/init.lua"
 
-export LUA_CPATH$k="\
-$goboSystem/Aliens/LuaRocks/lib/lua/$v/?.so;\
-$goboSystem/Aliens/LuaRocks/lib/lua/$v/loadall.so;;"
+export LUA_CPATH$k+="\
+;$goboSystem/Aliens/LuaRocks/lib/lua/$v/?.so;\
+$goboSystem/Aliens/LuaRocks/lib/lua/$v/loadall.so"
 
 done
 unset v k vk

--- a/LuaRocks/3.9.0/Resources/Environment
+++ b/LuaRocks/3.9.0/Resources/Environment
@@ -5,15 +5,15 @@ do
   v="${vk%=*}"
   k="${vk#*=}"
 
-export LUA_PATH$k="\
-$goboSystem/Aliens/LuaRocks/share/lua/$v/?.lua;\
+export LUA_PATH$k+="\
+;$goboSystem/Aliens/LuaRocks/share/lua/$v/?.lua;\
 $goboSystem/Aliens/LuaRocks/share/lua/$v/?/init.lua;\
 $goboSystem/Aliens/LuaRocks/lib/lua/$v/?.lua;\
-$goboSystem/Aliens/LuaRocks/lib/lua/$v/?/init.lua;;"
+$goboSystem/Aliens/LuaRocks/lib/lua/$v/?/init.lua"
 
-export LUA_CPATH$k="\
-$goboSystem/Aliens/LuaRocks/lib/lua/$v/?.so;\
-$goboSystem/Aliens/LuaRocks/lib/lua/$v/loadall.so;;"
+export LUA_CPATH$k+="\
+;$goboSystem/Aliens/LuaRocks/lib/lua/$v/?.so;\
+$goboSystem/Aliens/LuaRocks/lib/lua/$v/loadall.so"
 
 done
 unset v k vk

--- a/LuaRocks/3.9.2/Resources/Environment
+++ b/LuaRocks/3.9.2/Resources/Environment
@@ -5,15 +5,15 @@ do
   v="${vk%=*}"
   k="${vk#*=}"
 
-export LUA_PATH$k="\
-$goboSystem/Aliens/LuaRocks/share/lua/$v/?.lua;\
+export LUA_PATH$k+="\
+;$goboSystem/Aliens/LuaRocks/share/lua/$v/?.lua;\
 $goboSystem/Aliens/LuaRocks/share/lua/$v/?/init.lua;\
 $goboSystem/Aliens/LuaRocks/lib/lua/$v/?.lua;\
-$goboSystem/Aliens/LuaRocks/lib/lua/$v/?/init.lua;;"
+$goboSystem/Aliens/LuaRocks/lib/lua/$v/?/init.lua"
 
-export LUA_CPATH$k="\
-$goboSystem/Aliens/LuaRocks/lib/lua/$v/?.so;\
-$goboSystem/Aliens/LuaRocks/lib/lua/$v/loadall.so;;"
+export LUA_CPATH$k+="\
+;$goboSystem/Aliens/LuaRocks/lib/lua/$v/?.so;\
+$goboSystem/Aliens/LuaRocks/lib/lua/$v/loadall.so"
 
 done
 unset v k vk


### PR DESCRIPTION
`Lua` and `LuaRocks` both set (overwrite) the `LUA_PATH` variables, meaning which ever's `Environment` file is sourced last, is the only one taken into account. This fixes that for `Lua >= 5.3.0` and `LuaRocks >= 3.0.1` by making the change to append their paths instead of overwriting.

w/o this some packages fail to build when they need to use `LuaRocks` modules, one example is `Awesome 4.3`

#128