### PR TITLE
Fix LibArchive 3.4.2

### DIFF
--- a/LibArchive/3.4.2/Recipe
+++ b/LibArchive/3.4.2/Recipe
@@ -1,7 +1,15 @@
 # Recipe for version 3.4.2 by Lucas C. Villa Real <lucasvr@gobolinux.org>, on Sun 16 Feb 2020 12:59:41 AM BRT
 # Recipe (MakeRecipe) for LibArchive by Giambattista Bloisi <giamby@infinito.it>, on Tue Jan 15 23:31:17 CET 2008
 compile_version=1.10.0
-url="http://www.libarchive.org/downloads/libarchive-3.1.2.tar.gz"
-file_size=4527540
-file_md5=efad5a503f66329bb9d2f4308b5de98a
+url="https://www.libarchive.org/downloads/libarchive-3.4.2.tar.xz"
+file_size=4812472 
+file_md5=50abb48fe21135ff3b18679d07d8093e 
 recipe_type=configure
+configure_options=(
+   --prefix=$target
+   --disable-static
+   --without-expat
+   --with-xml2
+   --with-nettle
+   --with-lzo2
+)

--- a/LibArchive/3.4.2/Resources/Dependencies
+++ b/LibArchive/3.4.2/Resources/Dependencies
@@ -1,4 +1,13 @@
+Glibc 2.30
+ACL 2.2.53
+ATTR 2.4.48
+Bzip2 1.0.8
+LibArchive 3.4.2
+LibXML2 2.9.10
+LZ4 1.9.2
+LZO 2.10
+Nettle 3.5.1
+OpenSSL 1.1.1d
+XZ-Utils 5.2.5
 ZLib 1.2.11
-LZO >= 2.10
-LibXML2 >= 2.9.10
-Nettle >= 3.5.1
+Zstd 1.4.4


### PR DESCRIPTION
* fix `url` to download correct version
* added `configure_options`
  - only install shared libraries
  - use `Nettle` for crypto support
  - use `LibXML2` (not `Expat`) for xar archives
  - build with `LZO` support
* regenerated the `Dependencies` file (original works fine atm, as they are already added to the runner by `Compile` and `Scripts`'s Dependencies, but incase something changes, it's nice to have a more complete list.)

On a base install of Gobo017 it fails to build, as `Bzip2` doesn't have `libbz2.so` created, however, if you re-compile `Bzip2`, or create the symlink yourself, it'll work nicely even with `--pure`.

Would also like to note, due to the URL mix-up, Gobo017 comes with `LibArchive 3.1.2` installed into the `/Programs/LibArchive/3.4.2` folder. This is verified by the `archive.h` file listing `3.1.2` as the version.