### PR TITLE
GRUB, GRUB-EFI 2.12: Unify recipes into a common form

### DIFF
--- a/GRUB-EFI/2.12/Recipe
+++ b/GRUB-EFI/2.12/Recipe
@@ -1,4 +1,4 @@
-# Recipe for version 2.12 by Nuc1eoN, on Sun 13 Oct 2024 11:56:20 PM CEST
+# Recipe for version 2.12 by Nuc1eoN, on Sun 17 Apr 2025 11:56:20 PM CEST
 # Recipe (MakeRecipe) for GRUB by Lucas C. Villa Real, on Fri Dec 4 16:02:55 BRST 2009
 compile_version=017
 
@@ -28,24 +28,21 @@ environment=(
 )
 
 configure_options=(
-    --enable-device-mapper
     --enable-nls
-    --enable-grub-mount
+    --enable-device-mapper
     --enable-grub-mkfont
+    --enable-grub-mount
     --disable-silent-rules
+    --disable-efiemu
     --disable-werror
     --with-platform="efi"
     --program-suffix="-efi"
 )
 
 pre_build() {
-    # Avoid error in GRUB 2.12 build due to extra_deps.lst missing from source tarball:
-    #       make[3]: *** No rule to make target 'grub-core/extra_deps.lst', needed by 'syminfo.lst'.  Stop.
-    # Taken from: https://gitweb.gentoo.org/repo/gentoo.git/tree/sys-boot/grub/grub-2.12-r5.ebuild#n183
+    # Avoid build error in GRUB 2.12, due to extra_deps.lst missing from source tarball
+    # Taken from: https://gitweb.gentoo.org/repo/gentoo.git/tree/sys-boot/grub/grub-2.12-r6.ebuild#n183
     echo "depends bli part_gpt" > grub-core/extra_deps.lst || die
-    echo "Fix DejaVuSans.ttf location so that grub-mkfont can create *.pf2 files for starfield theme..."
-    sed 's|/usr/share/fonts/dejavu|/usr/share/fonts/dejavu /usr/share/fonts/TTF|g' -i "configure.ac"
-
 }
 
 pre_link() {

--- a/GRUB-EFI/2.12/i686/Recipe
+++ b/GRUB-EFI/2.12/i686/Recipe
@@ -1,7 +1,0 @@
-# arch=i686
-
-configure_options=(
-    ${configure_options[@]}
-    --disable-efiemu
-    --target="i386"
-)

--- a/GRUB-EFI/2.12/x86_64/Recipe
+++ b/GRUB-EFI/2.12/x86_64/Recipe
@@ -1,7 +1,0 @@
-# arch=x86_64
-
-configure_options=(
-    ${configure_options[@]}
-    --disable-efiemu
-    --target="x86_64"
-)

--- a/GRUB/2.12/02-add-GRUB_COLOR_variables.patch
+++ b/GRUB/2.12/02-add-GRUB_COLOR_variables.patch
@@ -1,0 +1,41 @@
+From 21e5bcf22ab1a9f08c63e2a0212219d7482f77c1 Mon Sep 17 00:00:00 2001
+From: Christian Hesse <mail@eworm.de>
+Date: Wed, 10 Mar 2021 18:42:25 +0100
+Subject: [PATCH] 00_header: add GRUB_COLOR_* variables
+---
+ util/grub-mkconfig.in    | 2 ++
+ util/grub.d/00_header.in | 8 ++++++++
+ 2 files changed, 10 insertions(+)
+
+diff --git a/util/grub-mkconfig.in b/util/grub-mkconfig.in
+index f8cbb8d7a..1189d95f9 100644
+--- a/util/grub-mkconfig.in
++++ b/util/grub-mkconfig.in
+@@ -246,6 +246,8 @@ export GRUB_DEFAULT \
+   GRUB_BACKGROUND \
+   GRUB_THEME \
+   GRUB_GFXPAYLOAD_LINUX \
++  GRUB_COLOR_NORMAL \
++  GRUB_COLOR_HIGHLIGHT \
+   GRUB_INIT_TUNE \
+   GRUB_SAVEDEFAULT \
+   GRUB_ENABLE_CRYPTODISK \
+diff --git a/util/grub.d/00_header.in b/util/grub.d/00_header.in
+index 93a90233e..c5955df00 100644
+--- a/util/grub.d/00_header.in
++++ b/util/grub.d/00_header.in
+@@ -125,6 +125,14 @@ cat <<EOF
+ 
+ EOF
+ 
++if [ x$GRUB_COLOR_NORMAL != x ] && [ x$GRUB_COLOR_HIGHLIGHT != x ] ; then
++    cat << EOF
++set menu_color_normal=$GRUB_COLOR_NORMAL
++set menu_color_highlight=$GRUB_COLOR_HIGHLIGHT
++
++EOF
++fi
++
+ serial=0;
+ gfxterm=0;
+ for x in ${GRUB_TERMINAL_INPUT} ${GRUB_TERMINAL_OUTPUT}; do

--- a/GRUB/2.12/Recipe
+++ b/GRUB/2.12/Recipe
@@ -1,49 +1,51 @@
-# Recipe for version 2.12 by Nuc1eoN, on Sun 13 Oct 2024 11:56:20 PM CEST
+# Recipe for version 2.12 by Nuc1eoN, on Sun 17 Apr 2025 11:56:20 PM CEST
 # Recipe (MakeRecipe) for GRUB by Lucas C. Villa Real, on Fri Dec 4 16:02:55 BRST 2009
 compile_version=017
-url="$ftpGnu/grub/grub-2.12.tar.xz"
-file_size=6675608
-file_md5=60c564b1bdc39d8e43b3aab4bc0fb140
+
+urls=(
+    "$ftpGnu/grub/grub-2.12.tar.xz"
+    "https://unifoundry.com/pub/unifont/unifont-16.0.02/font-builds/unifont-16.0.02.pcf.gz"
+)
+file_sizes=(
+    6675608
+    1356741
+)
+file_md5s=(
+    60c564b1bdc39d8e43b3aab4bc0fb140
+    91dc370f8115ddeef75e770c9023c498
+)
 autogen_before_configure=yes
 recipe_type=configure
 
 environment=(
-	CFLAGS="-DDEVDIR=\\\"$goboDevices\\\""
-	# Grub is not compatble with gold linker (https://bugs.gentoo.org/439082)
-	TARGET_LDFLAGS+="-fuse-ld=bfd"
+    CFLAGS=
+    CXXFLAGS=
+    CPPFLAGS=
+    LDFLAGS=
+    MAKEFLAGS=
+    # Grub is not compatble with gold linker (https://bugs.gentoo.org/439082)
+    TARGET_LDFLAGS+="-fuse-ld=bfd"
 )
 
 configure_options=(
-	--enable-device-mapper
-	--disable-werror
-	--disable-efiemu
+    --enable-nls
+    --enable-device-mapper
+    --enable-grub-mkfont
+    --enable-grub-mount
+    --disable-silent-rules
+    --disable-efiemu
+    --disable-werror
 )
 
 pre_build() {
-	# Avoid error in GRUB 2.12 build due to extra_deps.lst missing from source tarball:
-	#       make[3]: *** No rule to make target 'grub-core/extra_deps.lst', needed by 'syminfo.lst'.  Stop.
-	# Taken from: https://gitweb.gentoo.org/repo/gentoo.git/tree/sys-boot/grub/grub-2.12-r5.ebuild#n183
-	echo "depends bli part_gpt" > grub-core/extra_deps.lst || die
-	echo "Fix DejaVuSans.ttf location so that grub-mkfont can create *.pf2 files for starfield theme..."
-	sed 's|/usr/share/fonts/dejavu|/usr/share/fonts/dejavu /usr/share/fonts/TTF|g' -i "configure.ac"
-}
-
-pre_install() {
-	if grep -q "Apple Internal Keyboard / Trackpad" /sys/class/input/*/name 2> /dev/null
-	then
-		mkdir -p "$target/Resources/Unmanaged/$goboBoot"
-		dd if=/dev/mem of="$target/Resources/Unmanaged/$goboBoot/vbios.bin" bs=65536 skip=12 count=1
-		dd if=/dev/mem of="$target/Resources/Unmanaged/$goboBoot/int10.bin" bs=4     skip=16 count=1
-
-		#Quiet pushd grub-core
-		#../grub-mkimage -d . -o bootx64.efi -O x86_64-efi -p /efi/boot `find *.mod | xargs | sed -e 's/.mod//g'`
-		#../grub-mkimage -d . -o boot-i386.efi -O -i386-efi -p /efi/boot `find *.mod | xargs | sed -e 's/.mod//g'`
-		#Quiet popd
-	fi
+    # Avoid build error in GRUB 2.12, due to extra_deps.lst missing from source tarball
+    # Taken from: https://gitweb.gentoo.org/repo/gentoo.git/tree/sys-boot/grub/grub-2.12-r5.ebuild#n183
+    echo "depends bli part_gpt" > grub-core/extra_deps.lst || die
 }
 
 pre_link() {
-	case $(uname -m) in
-		x86_64) ln -sv lib $target/lib64 ;;
-	esac
+    ./grub-mkfont -o unicode.pf2 $compileArchivesDir/unifont-16.0.02.pcf.gz
+    mkdir -p $target/share/grub
+    cp -v unicode.pf2 $target/share/grub
+    rm -f $settings_target/grub.d/*_*efi
 }


### PR DESCRIPTION
This commit makes the GRUB recipe independant of the GRUB-EFI recipe - both recipes are now fully selfcontained. Also they have been unified into a commont form, to ease future maintainance.

Changes:

- GRUB: Add GRUB_COLOR_variables patch

- GRUB: Remove legacy pre-install hook

- GRUB: Install font

- GRUB-EFI: Remove dedicated i686 and x86_64 recipes

- GRUB, GRUB-EFI: Remove workaround to compile starfield theme. We don't need it.

- GRUB & GRUB-EFI: Recipes are now identical apart from --with-platform="efi" and --program-suffix="-efi" on the latter.

----------

@sage-etcher would you mind reviewing this PR for correctness? Both compiled fine for me.
(Before merging I shall test this on a LiveISO as well - Let's not break the bootloader again lol 🫠)