### PR TITLE
SIMDe 0.8.2

### DIFF
--- a/SIMDe/0.8.2/Recipe
+++ b/SIMDe/0.8.2/Recipe
@@ -1,0 +1,9 @@
+# Recipe (MakeRecipe) for SIMDe by eMorph <charlie+github@zoned.net>, on Sun 15 Jun 2025 12:56:37 PM EDT
+# Recipe for version 0.8.2 by eMorph <charlie+github@zoned.net>, on Sun 15 Jun 2025 12:56:37 PM EDT
+compile_version=017-GIT
+url="https://github.com/simd-everywhere/simde/archive/refs/tags/v0.8.2.tar.gz"
+file="simde-0.8.2.tar.gz"
+file_size=7468969
+file_md5=14323994d1f791e985c59ddf0b559e35
+dir='simde-0.8.2'
+recipe_type=meson

--- a/SIMDe/0.8.2/Resources/Description
+++ b/SIMDe/0.8.2/Resources/Description
@@ -1,0 +1,4 @@
+[Name] SIMDe
+[Description] Implementations of SIMD instruction sets for systems which don't natively support them.
+[License] MIT
+[Homepage] https://simd-everywhere.github.io/blog/


### PR DESCRIPTION
Some cross-platform applications use this to ensure SIMD exists. Needed as a build dependency for e.g. SuperTuxKart.